### PR TITLE
Prevented Issue where cart load reads string out of bounds

### DIFF
--- a/src/pemsa/cart/pemsa_cartridge_module.cpp
+++ b/src/pemsa/cart/pemsa_cartridge_module.cpp
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <filesystem>
 
+#include <sstream>
+
 #define STATE_LUA 0
 #define STATE_GFX 1
 #define STATE_GFF 2
@@ -198,6 +200,10 @@ bool PemsaCartridgeModule::load(const char *path) {
 			}
 
 			case STATE_MUSIC: {
+				if (line.size() < 11) {
+					break;
+				}
+
 				uint8_t flag = (HEX_TO_INT(line.at(0)) << 4) + HEX_TO_INT(line.at(1));
 				uint8_t val1 = (HEX_TO_INT(line.at(3)) << 4) + HEX_TO_INT(line.at(4));
 				uint8_t val2 = (HEX_TO_INT(line.at(5)) << 4) + HEX_TO_INT(line.at(6));

--- a/src/pemsa/cart/pemsa_cartridge_module.cpp
+++ b/src/pemsa/cart/pemsa_cartridge_module.cpp
@@ -12,8 +12,6 @@
 #include <cstring>
 #include <filesystem>
 
-#include <sstream>
-
 #define STATE_LUA 0
 #define STATE_GFX 1
 #define STATE_GFF 2
@@ -163,6 +161,10 @@ bool PemsaCartridgeModule::load(const char *path) {
 			}
 
 			case STATE_SFX: {
+				if (line.size() < 8) {
+					break;
+				}
+
 				uint8_t editor = (HEX_TO_INT(line.at(0)) << 4) + HEX_TO_INT(line.at(1));
 				uint8_t speed = (HEX_TO_INT(line.at(2)) << 4) + HEX_TO_INT(line.at(3));
 				uint8_t startLoop = (HEX_TO_INT(line.at(4)) << 4) + HEX_TO_INT(line.at(5));


### PR DESCRIPTION
It seems there can be empty lines in data section for carts. Music and SFX areas weren't taking that into account.