### PR TITLE
fixed bug where strings that included a quote inside would get recogn…

### DIFF
--- a/src/pemsa/cart/pemsa_scanner.cpp
+++ b/src/pemsa/cart/pemsa_scanner.cpp
@@ -114,12 +114,14 @@ PemsaToken PemsaScanner::scan() {
 		case '\'':
 		case '"': {
 			char stringStart = c;
+			char last = c;
 
-			while (this->peek() != stringStart && !this->isAtEnd()) {
+			while ((this->peek() != stringStart || last == '\\') && !this->isAtEnd()) {
 				if (this->peek() == '\n') {
 					this->line++;
 				}
 
+				last = this->peek();
 				this->advance();
 			}
 


### PR DESCRIPTION
…ized as the end of the string

strings such as "this is a quote: \"" would get parsed as "this is a quote\" instead