### PR TITLE
Fix foreach behavior to match PICO-8

### DIFF
--- a/src/pemsa/cart/pemsa_emitter.cpp
+++ b/src/pemsa/cart/pemsa_emitter.cpp
@@ -94,7 +94,7 @@ function all(a)
  if a == nil or n == 0 then 
   return function() end 
  end 
- local i = 0
+ local i = 1
  local previous_i = nil
  return function() 
   if (a[i] == previous_i) then

--- a/src/pemsa/cart/pemsa_emitter.cpp
+++ b/src/pemsa/cart/pemsa_emitter.cpp
@@ -77,14 +77,7 @@ A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z = -
 sub, cocreate, coresume, yield, costatus, debug, run = string.sub, coroutine.create, coroutine.resume, coroutine.yield, coroutine.status, nil, __reset
 
 function foreach(a, f)
- if not a then return end
- local copy={}
- for i=1,#a do
-  if a[i] ~= nil then table.insert(copy,a[i]) end
- end
- for i=1,#copy do
-  f(copy[i])
- end
+ for i in all(a) do f(i) end
 end
 function count(a) if not a then return 0 end return #a end 
 function arraylen(t)
@@ -97,16 +90,20 @@ function arraylen(t)
  return len 
 end 
 function all(a) 
- if a == nil then 
+ local n = arraylen(a)
+ if a == nil or n == 0 then 
   return function() end 
  end 
  local i = 0
- local n = arraylen(a) 
+ local previous_i = nil
  return function() 
-  i = i + 1 
+  if (a[i] == previous_i) then
+   i = i + 1
+  end
   while (a[i] == nil and i <= n) do 
    i = i + 1 
   end 
+  previous_i = a[i]
   return a[i] 
  end 
 end 


### PR DESCRIPTION
PICO-8 doesn't make a copy of the table in the foreach function, which allows things like this:
```lua
t = {1,2,3}

foreach(t, function(o)
    print(o)
    if o == 2 then
        t[4] = 4
    end
end)
```
which outputs
```
1
2
3
4
```
in PICO-8 but only goes up to 3 in pemsa (because it'll only see the changes after the foreach is done).
Behavior of the `all` function has also been changed to match PICO-8 (would cause problems in certain situations otherwise).